### PR TITLE
Setup second test case for radiosity.

### DIFF
--- a/lib/radiosity.h
+++ b/lib/radiosity.h
@@ -38,3 +38,30 @@ float form_factor(const KDTree& tree, const Triangle& from, const Triangle& to,
 float form_factor(const KDTree& tree, const KDTree::TriangleId from_id,
                   const KDTree::TriangleId to_id,
                   const size_t num_samples = 128);
+
+/**
+ * Compute form factor of two parallel rectangles with sides a, b analytically.
+ *
+ * Cf. [CW93], 4.6, p. 73
+ *
+ * @param  a side of rectangles
+ * @param  b side of rectangles
+ * @param  c distance of rectangles
+ * @return   form factor
+ */
+float form_factor_of_parallel_rects(float a, float b, float c);
+
+/**
+ * Compute form factor of orthogonal rectangles with sides a, c and b, c
+ * analytically.
+ *
+ * Note: Both rectangles have the same side c, and a and b are orthogonal.
+ *
+ * Cf. [CW93], 4.6, p. 73
+ *
+ * @param  a side of rectangles
+ * @param  b side of rectangles
+ * @param  c distance of rectangles
+ * @return   form factor
+ */
+float form_factor_of_orthogonal_rects(float a, float b, float c);

--- a/tests/test_radiosity.cpp
+++ b/tests/test_radiosity.cpp
@@ -4,7 +4,7 @@
 
 namespace {
 constexpr float NUM_SAMPLES = 32;
-constexpr float TOLERANCE = 0.01f;
+constexpr float TOLERANCE = 0.1f;
 }
 
 TEST_CASE("Form factor of two parallel unit squares one unit apart",
@@ -56,19 +56,16 @@ TEST_CASE("Form factor of two parallel unit squares one unit apart",
     REQUIRE(F_23_01 == Approx(F_EXPECTED).epsilon(TOLERANCE));
 }
 
-TEST_CASE("Form factor of two parallel unit squares with 90 degree angle",
+TEST_CASE("Form factor of two orthogonal unit squares with 90 degree angle",
           "[form_factor]") {
-    // two triangulated parallel unit squares one unit distance apart,
-    auto bottom_left =
-        test_triangle({0.f, 0.f, 0.f}, {1.f, 0.f, 0.f}, {0.f, 0.f, 1.f},
-                      {0, 1, 0}, {0, 1, 0}, {0, 1, 0}); // 0
-    auto bottom_right =
-        test_triangle({0.f, 0.f, 1.f}, {1.f, 0.f, 0.f}, {1.f, 1.f, 0},
-                      {0, 1, 0}, {0, 1, 0}, {0, 1, 0}); // 1
-    auto back_left = test_triangle({0.f, 0.f, 1}, {1.f, 0.f, 1}, {0.0, 1.f, 1},
-                                   {0, 0, -1}, {0, 0, -1}, {0, 0, -1}); // 2
-    auto back_right = test_triangle({0.f, 1.f, 1}, {1.f, 0.f, 1}, {1.f, 1.f, 1},
-                                    {0, 0, -1}, {0, 0, -1}, {0, 0, -1}); // 3
+    auto bottom_left = test_triangle({0, 0, 0}, {1, 0, 1}, {1, 0, 0}, {0, 1, 0},
+                                     {0, 1, 0}, {0, 1, 0}); // 0
+    auto bottom_right = test_triangle({0, 0, 0}, {0, 0, 1}, {1, 0, 1},
+                                      {0, 1, 0}, {0, 1, 0}, {0, 1, 0}); // 1
+    auto back_left = test_triangle({0, 0, 0}, {1, 0, 0}, {1, 1, 0}, {0, 0, 1},
+                                   {0, 0, 1}, {0, 0, 1}); // 2
+    auto back_right = test_triangle({0, 0, 0}, {1, 1, 0}, {0, 1, 0}, {0, 0, 1},
+                                    {0, 0, 1}, {0, 0, 1}); // 3
     KDTree tree({bottom_left, bottom_right, back_left, back_right});
 
     // compute the form factor F_(bottom,top) = F_01_23 using the form factor
@@ -85,7 +82,7 @@ TEST_CASE("Form factor of two parallel unit squares with 90 degree angle",
     float F_01_23 = F_01_2 + F_01_3;
 
     // TODO: Calculate expected value analytically
-    constexpr float F_EXPECTED = 0.01188f;
+    constexpr float F_EXPECTED = 0.2;
     REQUIRE(F_01_23 == Approx(F_EXPECTED).epsilon(TOLERANCE));
 
     // symmetry test

--- a/tests/test_radiosity.cpp
+++ b/tests/test_radiosity.cpp
@@ -55,3 +55,50 @@ TEST_CASE("Form factor of two parallel unit squares one unit apart",
 
     REQUIRE(F_23_01 == Approx(F_EXPECTED).epsilon(TOLERANCE));
 }
+
+TEST_CASE("Form factor of two parallel unit squares with 90 degree angle",
+          "[form_factor]") {
+    // two triangulated parallel unit squares one unit distance apart,
+    auto bottom_left =
+        test_triangle({0.f, 0.f, 0.f}, {1.f, 0.f, 0.f}, {0.f, 0.f, 1.f},
+                      {0, 1, 0}, {0, 1, 0}, {0, 1, 0}); // 0
+    auto bottom_right =
+        test_triangle({0.f, 0.f, 1.f}, {1.f, 0.f, 0.f}, {1.f, 1.f, 0},
+                      {0, 1, 0}, {0, 1, 0}, {0, 1, 0}); // 1
+    auto back_left = test_triangle({0.f, 0.f, 1}, {1.f, 0.f, 1}, {0.0, 1.f, 1},
+                                   {0, 0, -1}, {0, 0, -1}, {0, 0, -1}); // 2
+    auto back_right = test_triangle({0.f, 1.f, 1}, {1.f, 0.f, 1}, {1.f, 1.f, 1},
+                                    {0, 0, -1}, {0, 0, -1}, {0, 0, -1}); // 3
+    KDTree tree({bottom_left, bottom_right, back_left, back_right});
+
+    // compute the form factor F_(bottom,top) = F_01_23 using the form factor
+    // algebra
+    float F_0_2 = form_factor(tree, bottom_left, back_left, 2, NUM_SAMPLES);
+    float F_0_3 = form_factor(tree, bottom_left, back_right, 3, NUM_SAMPLES);
+    float F_1_2 = form_factor(tree, bottom_right, back_left, 2, NUM_SAMPLES);
+    float F_1_3 = form_factor(tree, bottom_right, back_right, 3, NUM_SAMPLES);
+
+    float F_01_2 = (bottom_left.area() * F_0_2 + bottom_right.area() * F_1_2) /
+                   (bottom_left.area() + bottom_right.area());
+    float F_01_3 = (bottom_left.area() * F_0_3 + bottom_right.area() * F_1_3) /
+                   (bottom_left.area() + bottom_right.area());
+    float F_01_23 = F_01_2 + F_01_3;
+
+    // TODO: Calculate expected value analytically
+    constexpr float F_EXPECTED = 0.01188f;
+    REQUIRE(F_01_23 == Approx(F_EXPECTED).epsilon(TOLERANCE));
+
+    // symmetry test
+    float F_2_0 = form_factor(tree, back_left, bottom_left, 0, NUM_SAMPLES);
+    float F_2_1 = form_factor(tree, back_left, bottom_right, 1, NUM_SAMPLES);
+    float F_3_0 = form_factor(tree, back_right, bottom_left, 0, NUM_SAMPLES);
+    float F_3_1 = form_factor(tree, back_right, bottom_right, 1, NUM_SAMPLES);
+
+    float F_23_0 = (back_left.area() * F_2_0 + back_right.area() * F_3_0) /
+                   (back_left.area() + back_right.area());
+    float F_23_1 = (back_left.area() * F_2_1 + back_right.area() * F_3_1) /
+                   (back_left.area() + back_right.area());
+    float F_23_01 = F_23_0 + F_23_1;
+
+    REQUIRE(F_23_01 == Approx(F_EXPECTED).epsilon(TOLERANCE));
+}

--- a/tests/test_radiosity.cpp
+++ b/tests/test_radiosity.cpp
@@ -2,100 +2,156 @@
 #include "helper.h"
 #include <catch.hpp>
 
+#include <random>
+
 namespace {
 constexpr float NUM_SAMPLES = 32;
 constexpr float TOLERANCE = 0.1f;
+constexpr size_t NUM_RANDOM_TESTS = 50;
+
+std::pair<float, float> parallel_scenario(float a, float b, float c) {
+    auto bottom_lft = test_triangle({0, 0, 0}, {a, 0, b}, {a, 0, 0});
+    auto bottom_rht = test_triangle({0, 0, 0}, {0, 0, b}, {a, 0, b});
+    auto top_lft = test_triangle({0, c, 0}, {a, c, 0}, {a, c, b});
+    auto top_rht = test_triangle({0, c, 0}, {a, c, b}, {0, c, b});
+    KDTree tree({bottom_lft, bottom_rht, top_lft, top_rht});
+
+    // compute the form factor F_(bottom,top) = F_01_23 using the form
+    // factor algebra
+    float F_0_2 = form_factor(tree, bottom_lft, top_lft, 2, NUM_SAMPLES);
+    float F_0_3 = form_factor(tree, bottom_lft, top_rht, 3, NUM_SAMPLES);
+    float F_1_2 = form_factor(tree, bottom_rht, top_lft, 2, NUM_SAMPLES);
+    float F_1_3 = form_factor(tree, bottom_rht, top_rht, 3, NUM_SAMPLES);
+
+    float F_01_2 = (bottom_lft.area() * F_0_2 + bottom_rht.area() * F_1_2) /
+                   (bottom_lft.area() + bottom_rht.area());
+    float F_01_3 = (bottom_lft.area() * F_0_3 + bottom_rht.area() * F_1_3) /
+                   (bottom_lft.area() + bottom_rht.area());
+    float F_01_23 = F_01_2 + F_01_3;
+
+    // reciproc factor
+    float F_2_0 = form_factor(tree, top_lft, bottom_lft, 0, NUM_SAMPLES);
+    float F_2_1 = form_factor(tree, top_lft, bottom_rht, 1, NUM_SAMPLES);
+    float F_3_0 = form_factor(tree, top_rht, bottom_lft, 0, NUM_SAMPLES);
+    float F_3_1 = form_factor(tree, top_rht, bottom_rht, 1, NUM_SAMPLES);
+
+    float F_23_0 = (top_lft.area() * F_2_0 + top_rht.area() * F_3_0) /
+                   (top_lft.area() + top_rht.area());
+    float F_23_1 = (top_lft.area() * F_2_1 + top_rht.area() * F_3_1) /
+                   (top_lft.area() + top_rht.area());
+    float F_23_01 = F_23_0 + F_23_1;
+
+    return {F_01_23, F_23_01};
+}
+
+std::pair<float, float> orthogonal_scenario(float a, float b, float c) {
+    auto bottom_lft = test_triangle({0, 0, 0}, {c, 0, b}, {c, 0, 0}); // 0
+    auto bottom_rht = test_triangle({0, 0, 0}, {0, 0, b}, {c, 0, b}); // 1
+    auto back_lft = test_triangle({0, 0, 0}, {c, 0, 0}, {c, a, 0});   // 2
+    auto back_rht = test_triangle({0, 0, 0}, {c, a, 0}, {0, a, 0});   // 3
+    KDTree tree({bottom_lft, bottom_rht, back_lft, back_rht});
+
+    // compute the form factor F_(bottom,top) = F_01_23 using the form
+    // factor algebra
+    float F_0_2 = form_factor(tree, bottom_lft, back_lft, 2, NUM_SAMPLES);
+    float F_0_3 = form_factor(tree, bottom_lft, back_rht, 3, NUM_SAMPLES);
+    float F_1_2 = form_factor(tree, bottom_rht, back_lft, 2, NUM_SAMPLES);
+    float F_1_3 = form_factor(tree, bottom_rht, back_rht, 3, NUM_SAMPLES);
+
+    float F_01_2 = (bottom_lft.area() * F_0_2 + bottom_rht.area() * F_1_2) /
+                   (bottom_lft.area() + bottom_rht.area());
+    float F_01_3 = (bottom_lft.area() * F_0_3 + bottom_rht.area() * F_1_3) /
+                   (bottom_lft.area() + bottom_rht.area());
+    float F_01_23 = F_01_2 + F_01_3;
+
+    // reciproc factor
+    float F_2_0 = form_factor(tree, back_lft, bottom_lft, 0, NUM_SAMPLES);
+    float F_2_1 = form_factor(tree, back_lft, bottom_rht, 1, NUM_SAMPLES);
+    float F_3_0 = form_factor(tree, back_rht, bottom_lft, 0, NUM_SAMPLES);
+    float F_3_1 = form_factor(tree, back_rht, bottom_rht, 1, NUM_SAMPLES);
+
+    float F_23_0 = (back_lft.area() * F_2_0 + back_rht.area() * F_3_0) /
+                   (back_lft.area() + back_rht.area());
+    float F_23_1 = (back_lft.area() * F_2_1 + back_rht.area() * F_3_1) /
+                   (back_lft.area() + back_rht.area());
+    float F_23_01 = F_23_0 + F_23_1;
+
+    return {F_01_23, F_23_01};
+}
 }
 
 TEST_CASE("Form factor of two parallel unit squares one unit apart",
           "[form_factor]") {
-    // two triangulated parallel unit squares one unit distance apart,
-    // cf. [CW93], Figure 4.22., p.96
-    auto bottom_left =
-        test_triangle({0.5, -0.5, 0}, {0.5, 0.5, 0}, {-0.5, 0.5, 0}, {0, 0, 1},
-                      {0, 0, 1}, {0, 0, 1}); // 0
-    auto bottom_right =
-        test_triangle({0.5, -0.5, 0}, {-0.5, 0.5, 0}, {-0.5, -0.5, 0},
-                      {0, 0, 1}, {0, 0, 1}, {0, 0, 1}); // 1
-    auto top_left =
-        test_triangle({-0.5f, 0.5f, 1}, {0.5, 0.5, 1}, {0.5, -0.5, 1},
-                      {0, 0, -1}, {0, 0, -1}, {0, 0, -1}); // 2
-    auto top_right =
-        test_triangle({-0.5f, 0.5f, 1}, {0.5, -0.5, 1}, {-0.5, -0.5, 1},
-                      {0, 0, -1}, {0, 0, -1}, {0, 0, -1}); // 3
-    KDTree tree({bottom_left, bottom_right, top_left, top_right});
+    float F_ij, F_ji;
+    std::tie(F_ij, F_ji) = parallel_scenario(1, 1, 1);
 
-    // compute the form factor F_(bottom,top) = F_01_23 using the form factor
-    // algebra
-    float F_0_2 = form_factor(tree, 0, 2, NUM_SAMPLES);
-    float F_0_3 = form_factor(tree, 0, 3, NUM_SAMPLES);
-    float F_1_2 = form_factor(tree, 1, 2, NUM_SAMPLES);
-    float F_1_3 = form_factor(tree, 1, 3, NUM_SAMPLES);
-
-    float F_01_2 = (bottom_left.area() * F_0_2 + bottom_right.area() * F_1_2) /
-                   (bottom_left.area() + bottom_right.area());
-    float F_01_3 = (bottom_left.area() * F_0_3 + bottom_right.area() * F_1_3) /
-                   (bottom_left.area() + bottom_right.area());
-    float F_01_23 = F_01_2 + F_01_3;
-
-    constexpr float F_EXPECTED = 0.1998; // cf. [CW93], 4.12., p.96
-    REQUIRE(F_01_23 == Approx(F_EXPECTED).epsilon(TOLERANCE));
-
-    // symmetry test
-    float F_2_0 = form_factor(tree, 2, 0, NUM_SAMPLES);
-    float F_2_1 = form_factor(tree, 2, 1, NUM_SAMPLES);
-    float F_3_0 = form_factor(tree, 3, 0, NUM_SAMPLES);
-    float F_3_1 = form_factor(tree, 3, 1, NUM_SAMPLES);
-
-    float F_23_0 = (top_left.area() * F_2_0 + top_right.area() * F_3_0) /
-                   (top_left.area() + top_right.area());
-    float F_23_1 = (top_left.area() * F_2_1 + top_right.area() * F_3_1) /
-                   (top_left.area() + top_right.area());
-    float F_23_01 = F_23_0 + F_23_1;
-
-    REQUIRE(F_23_01 == Approx(F_EXPECTED).epsilon(TOLERANCE));
+    constexpr float F_EXPECTED = 0.1998; // cf. [CW93], 4.12., p. 96
+    REQUIRE(F_ij == Approx(F_EXPECTED).epsilon(TOLERANCE));
+    REQUIRE(F_ji == Approx(F_EXPECTED).epsilon(TOLERANCE));
 }
 
-TEST_CASE("Form factor of two orthogonal unit squares with 90 degree angle",
-          "[form_factor]") {
-    auto bottom_left = test_triangle({0, 0, 0}, {1, 0, 1}, {1, 0, 0}, {0, 1, 0},
-                                     {0, 1, 0}, {0, 1, 0}); // 0
-    auto bottom_right = test_triangle({0, 0, 0}, {0, 0, 1}, {1, 0, 1},
-                                      {0, 1, 0}, {0, 1, 0}, {0, 1, 0}); // 1
-    auto back_left = test_triangle({0, 0, 0}, {1, 0, 0}, {1, 1, 0}, {0, 0, 1},
-                                   {0, 0, 1}, {0, 0, 1}); // 2
-    auto back_right = test_triangle({0, 0, 0}, {1, 1, 0}, {0, 1, 0}, {0, 0, 1},
-                                    {0, 0, 1}, {0, 0, 1}); // 3
-    KDTree tree({bottom_left, bottom_right, back_left, back_right});
+TEST_CASE("Form factor of two orthogonal unit squares", "[form_factor]") {
+    float F_ij, F_ji;
+    std::tie(F_ij, F_ji) = orthogonal_scenario(1, 1, 1);
 
-    // compute the form factor F_(bottom,top) = F_01_23 using the form factor
-    // algebra
-    float F_0_2 = form_factor(tree, bottom_left, back_left, 2, NUM_SAMPLES);
-    float F_0_3 = form_factor(tree, bottom_left, back_right, 3, NUM_SAMPLES);
-    float F_1_2 = form_factor(tree, bottom_right, back_left, 2, NUM_SAMPLES);
-    float F_1_3 = form_factor(tree, bottom_right, back_right, 3, NUM_SAMPLES);
-
-    float F_01_2 = (bottom_left.area() * F_0_2 + bottom_right.area() * F_1_2) /
-                   (bottom_left.area() + bottom_right.area());
-    float F_01_3 = (bottom_left.area() * F_0_3 + bottom_right.area() * F_1_3) /
-                   (bottom_left.area() + bottom_right.area());
-    float F_01_23 = F_01_2 + F_01_3;
-
-    // TODO: Calculate expected value analytically
     constexpr float F_EXPECTED = 0.2;
-    REQUIRE(F_01_23 == Approx(F_EXPECTED).epsilon(TOLERANCE));
+    REQUIRE(F_ij == Approx(F_EXPECTED).epsilon(TOLERANCE));
+    REQUIRE(F_ji == Approx(F_EXPECTED).epsilon(TOLERANCE));
+}
 
-    // symmetry test
-    float F_2_0 = form_factor(tree, back_left, bottom_left, 0, NUM_SAMPLES);
-    float F_2_1 = form_factor(tree, back_left, bottom_right, 1, NUM_SAMPLES);
-    float F_3_0 = form_factor(tree, back_right, bottom_left, 0, NUM_SAMPLES);
-    float F_3_1 = form_factor(tree, back_right, bottom_right, 1, NUM_SAMPLES);
+TEST_CASE(
+    "Form factor of two parallel unit squares one unit apart (analytically)",
+    "[form_factor]") {
+    float form_factor = form_factor_of_parallel_rects(1, 1, 1);
+    REQUIRE(form_factor == Approx(0.1998).epsilon(0.0001));
+}
 
-    float F_23_0 = (back_left.area() * F_2_0 + back_right.area() * F_3_0) /
-                   (back_left.area() + back_right.area());
-    float F_23_1 = (back_left.area() * F_2_1 + back_right.area() * F_3_1) /
-                   (back_left.area() + back_right.area());
-    float F_23_01 = F_23_0 + F_23_1;
+TEST_CASE("Form factor of two orthogonal unit squares (analytically)",
+          "[form_factor]") {
+    float form_factor = form_factor_of_orthogonal_rects(1, 1, 1);
+    REQUIRE(form_factor == Approx(0.2).epsilon(0.0001));
+}
 
-    REQUIRE(F_23_01 == Approx(F_EXPECTED).epsilon(TOLERANCE));
+TEST_CASE("Form factor of two random parallel rectangles", "[form_factor]") {
+    static std::default_random_engine gen(0);
+    static std::uniform_real_distribution<float> rnd(1, 10);
+
+    size_t passed = 0;
+    for (size_t i = 0; i < NUM_RANDOM_TESTS; ++i) {
+        float a = rnd(gen);
+        float b = rnd(gen);
+        float c = rnd(gen);
+
+        float F_ij, F_ji;
+        std::tie(F_ij, F_ji) = parallel_scenario(a, b, c);
+        float F_EXPECTED = form_factor_of_parallel_rects(a, b, c);
+        passed += F_ij == Approx(F_EXPECTED).epsilon(TOLERANCE);
+        passed += F_ji == Approx(F_EXPECTED).epsilon(TOLERANCE);
+    }
+
+    // Variance in Monte Carlo integration is too high, so we only require that
+    // 99% of all checks pass.
+    REQUIRE(2.0 * passed / NUM_RANDOM_TESTS > 0.99);
+}
+
+TEST_CASE("Form factor of two random orthogonal rectangles", "[form_factor]") {
+    static std::default_random_engine gen(0);
+    static std::uniform_real_distribution<float> rnd(1, 10);
+
+    size_t passed = 0;
+    for (size_t i = 0; i < NUM_RANDOM_TESTS; ++i) {
+        float a = rnd(gen);
+        float b = rnd(gen);
+        float c = rnd(gen);
+
+        float F_ij, F_ji;
+        std::tie(F_ij, F_ji) = parallel_scenario(a, b, c);
+        float F_EXPECTED = form_factor_of_parallel_rects(a, b, c);
+        passed += F_ij == Approx(F_EXPECTED).epsilon(TOLERANCE);
+        passed += F_ji == Approx(F_EXPECTED).epsilon(TOLERANCE);
+    }
+
+    // Variance in Monte Carlo integration is too high, so we only require that
+    // 99% of all checks pass.
+    REQUIRE(2.0 * passed / NUM_RANDOM_TESTS > 0.99);
 }


### PR DESCRIPTION
We determine the form factor between two unit squares that are
perpendicular to each other. The form factor has to be symmetrical and
can be determined analytically.