### PR TITLE
Compute form factors using the inf. area to disk formula from Cohen-Wallace

### DIFF
--- a/lib/radiosity.cpp
+++ b/lib/radiosity.cpp
@@ -18,54 +18,41 @@
 #include "radiosity.h"
 #include "sampling.h"
 
-/**
- * The form factor between faces `from` (i) and `to` (j) is defined as
- *
- * F_ij = 1/A_i ∫_x ∫_y G'(x, y) dA_y dA_x
- *      ≈ 1/A_i A_j/L ∑_{l = 1...L} (A_i/K ∑_{k = 1...K} G'(x^l, y^k))
- *      = A_j/N ∑_{n = 1...N} G'(x^n, y^n)
- *
- * Here, x and y are points on face i and j, A_i is the area of i, and A_i, and
- * A_j are infinitesimal areas around x and y. Further,
- *
- * G'(x, y) = V(x, y) * cos+(θ_i) * cos+(θ_j) / (π * ||x-y||^2), where
- *
- * V(x, y) - visibility indicator between x and y (1 if visible, 0 else)
- * θ_i - angle between normal of x and vector to y (ω)
- * θ_j - angle between normal of y and vector to x (-ω)
- *
- * The above integrals are approximated by Monte-Carlo.
- */
 float form_factor(const KDTree& tree, const Triangle& from, const Triangle& to,
                   const KDTree::TriangleId to_id, const size_t num_samples) {
     float result = 0;
-    for (size_t i = 0; i != num_samples; ++i) {
+    for (size_t i = 0; i < num_samples; ++i) {
         auto p1 = sampling::triangle(from);
         auto p2 = sampling::triangle(to);
 
-        auto v = p2 - p1;
+        Vec v = p2 - p1;
         if (tree.intersect(Ray{p1 + EPS * from.normal, v}) != to_id) {
             continue;
         }
 
         float square_length = v.SquareLength();
-        v.Normalize();
-
-        float cos_theta1 = v * from.normal;
-        if (cos_theta1 < 0) {
+        if (square_length == 0) {
             continue;
         }
 
-        float cos_theta2 = (-v) * to.normal;
-        if (cos_theta2 < 0) {
+        float length = sqrt(square_length);
+
+        float cos_theta1 = v * from.normal / length;
+        if (cos_theta1 <= 0) {
             continue;
         }
 
-        float G = cos_theta1 * cos_theta2 / square_length;
+        float cos_theta2 = (-v) * to.normal / length;
+        if (cos_theta2 <= 0) {
+            continue;
+        }
+
+        float G = cos_theta1 * cos_theta2 /
+                  (M_PI * square_length + to.area() / num_samples);
         result += G;
     }
 
-    return M_1_PI * result * to.area() / num_samples;
+    return result * to.area() / num_samples;
 }
 
 float form_factor(const KDTree& tree, const KDTree::TriangleId from_id,

--- a/lib/radiosity.h
+++ b/lib/radiosity.h
@@ -3,18 +3,25 @@
 #include "kdtree.h"
 
 /**
+ * Numerical integration of form factor from infinitesimal area to finite area.
+ *
+ * Cf. [CW93], 4.9, p. 91. and Algorithm 4.21.
+ *
  * The form factor between faces `from` (i) and `to` (j) is defined as
  *
  * F_ij = 1/A_i ∫_x ∫_y G'(x, y) dA_y dA_x
  *
- * Here, x and y are points on face i and j, A_i is the area of i, and A_i, and
- * A_j are infinitesimal areas around x and y. Further,
+ * Here, x and y are points on face i and j, A_i is an infinitesimal area on i
+ * around x, and A_j is the area of j. Further,
  *
  * G'(x, y) = V(x, y) * cos+(θ_i) * cos+(θ_j) / (π * ||x-y||^2), where
  *
  * V(x, y) - visibility indicator between x and y (1 if visible, 0 else)
  * θ_i - angle between normal of x and vector to y (ω)
  * θ_j - angle between normal of y and vector to x (-ω)
+ *
+ * @note When the distance from i to j is small relative to the size of j, the
+ *       result is inexact.
  *
  * @param  tree        Kd-tree used for determining V(x, y)
  * @param  from        Triangle i (does not need to be contained in tree)

--- a/tests/test_radiosity.cpp
+++ b/tests/test_radiosity.cpp
@@ -95,7 +95,7 @@ TEST_CASE("Form factor of two orthogonal unit squares", "[form_factor]") {
     float F_ij, F_ji;
     std::tie(F_ij, F_ji) = orthogonal_scenario(1, 1, 1);
 
-    constexpr float F_EXPECTED = 0.20004f;
+    constexpr float F_EXPECTED = 0.20004; // cf. [CW93], Figure 4.25., p. 100
     REQUIRE(F_ij == Approx(F_EXPECTED).epsilon(0.08));
     REQUIRE(F_ji == Approx(F_EXPECTED).epsilon(0.08));
 }
@@ -110,7 +110,7 @@ TEST_CASE(
 TEST_CASE("Form factor of two orthogonal unit squares (analytically)",
           "[form_factor]") {
     float form_factor = form_factor_of_orthogonal_rects(1, 1, 1);
-    REQUIRE(form_factor == Approx(0.2).epsilon(0.0001));
+    REQUIRE(form_factor == Approx(0.20004).epsilon(0.0001));
 }
 
 TEST_CASE("Form factor of two random parallel rectangles", "[form_factor]") {

--- a/tests/test_radiosity.cpp
+++ b/tests/test_radiosity.cpp
@@ -2,11 +2,12 @@
 #include "helper.h"
 #include <catch.hpp>
 
+#include <cmath>
 #include <random>
 
 namespace {
 constexpr float NUM_SAMPLES = 32;
-constexpr float TOLERANCE = 0.1f;
+constexpr float TOLERANCE = 0.01f;
 constexpr size_t NUM_RANDOM_TESTS = 50;
 
 std::pair<float, float> parallel_scenario(float a, float b, float c) {
@@ -94,9 +95,9 @@ TEST_CASE("Form factor of two orthogonal unit squares", "[form_factor]") {
     float F_ij, F_ji;
     std::tie(F_ij, F_ji) = orthogonal_scenario(1, 1, 1);
 
-    constexpr float F_EXPECTED = 0.2;
-    REQUIRE(F_ij == Approx(F_EXPECTED).epsilon(TOLERANCE));
-    REQUIRE(F_ji == Approx(F_EXPECTED).epsilon(TOLERANCE));
+    constexpr float F_EXPECTED = 0.20004f;
+    REQUIRE(F_ij == Approx(F_EXPECTED).epsilon(0.08));
+    REQUIRE(F_ji == Approx(F_EXPECTED).epsilon(0.08));
 }
 
 TEST_CASE(
@@ -154,4 +155,17 @@ TEST_CASE("Form factor of two random orthogonal rectangles", "[form_factor]") {
     // Variance in Monte Carlo integration is too high, so we only require that
     // 99% of all checks pass.
     REQUIRE(2.0 * passed / NUM_RANDOM_TESTS > 0.99);
+}
+
+TEST_CASE("Form factor distance dependency", "[form_factor]") {
+    static constexpr size_t NUM_STEPS = 100;
+    for (size_t i = 0; i < NUM_STEPS; ++i) {
+        float distance = std::sqrt(static_cast<float>(i + 1));
+        float F_ij, F_ji;
+        std::tie(F_ij, F_ji) = parallel_scenario(1, 1, distance);
+
+        const float F_EXPECTED = form_factor_of_parallel_rects(1, 1, distance);
+        REQUIRE(F_ij == Approx(F_ij).epsilon(TOLERANCE));
+        REQUIRE(F_ji == Approx(F_ij).epsilon(TOLERANCE)); // reciprocity
+    }
 }


### PR DESCRIPTION
* This ensures that numerical integration converges from below against the form
  factor. In particular, computed form factor is always <= 1.
* Add test to check the dependency between distance and form factor.
* Remove dead code.
* Remove integration explanation, which does not hold anymore.