### PR TITLE
Refine links after gathering and push-pull. 

### DIFF
--- a/lib/hierarchical.h
+++ b/lib/hierarchical.h
@@ -498,6 +498,16 @@ private:
     bool refine_links(Quadnode& p) {
         bool done = true;
 
+        // Process all child nodes first.
+        if (!p.is_leaf()) {
+            for (auto& child: p.children) {
+                if(!refine_links(*child.get())) {
+                    done = false;
+                }
+            }
+        }
+
+        // Post-order: Process links.
         // We create a copy of gathering links because refine_link might remove
         // elements.
         // TODO: Avoid the copy
@@ -508,16 +518,6 @@ private:
             }
         }
 
-        // Recursive for all child nodes.
-        // TODO: Use stack instead.
-        // TODO: BUG children will have refined links already. BAD.
-        if (!p.is_leaf()) {
-            for (auto& child: p.children) {
-                if(!refine_links(*child.get())) {
-                    done = false;
-                }
-            }
-        }
         return done;
     }
 

--- a/lib/hierarchical.h
+++ b/lib/hierarchical.h
@@ -534,7 +534,6 @@ private:
      * @return true if a link has been refined.
      */
     bool refine_link(Quadnode& p, Linknode& link_node) {
-        bool refined = false;
 
         // Shooter node p
         Quadnode& q = *link_node.q;
@@ -553,28 +552,28 @@ private:
             // Decide which side to subdivide. See refine()
             if (F_pq < F_qp) {
                 if (subdivide(p)) {
-                    refined = true;
-
                     // We've subdivided reciever node p. So all children of p
                     // should gather from q now.
                     for (auto& child : p.children) {
                         link(*child.get(), q);
                     }
+
+                    return true;
                 }
             } else {
                 if (subdivide(q)) {
-                    refined = true;
-
                     // We've subdivided shooter node q. So receiver node p
                     // should gather from all children of q now.
                     for (auto& child : q.children) {
                         link(p, *child.get());
                     }
+
+                    return true;
                 }
             }
         }
 
-        return refined;
+        return false;
     }
 
     void gather_radiosity(Quadnode& in) {

--- a/lib/hierarchical.h
+++ b/lib/hierarchical.h
@@ -184,7 +184,7 @@ public:
             std::cerr << "done." << std::endl;
 
             std::cerr << "Refine links...";
-            if(!refine_links()) {
+            if(refine_links()) {
                 done = false;
             }
             std::cerr << "done." << std::endl;
@@ -479,16 +479,16 @@ private:
 
     /**
      * Refine all links in all nodes.
-     * @return true if links have been refined.
+     * @return true if a link has been refined.
      */
     bool refine_links() {
-        bool done = true;
+        bool refined = false;
         for (auto& p : nodes_) {
-            if(!refine_links(p)) {
-                done = false;
+            if(refine_links(p)) {
+                refined = true;
             }
         }
-        return done;
+        return refined;
     }
 
     /**
@@ -496,13 +496,13 @@ private:
      * @return true if a link has been refined.
      */
     bool refine_links(Quadnode& p) {
-        bool done = true;
+        bool refined = false;
 
         // Process all child nodes first.
         if (!p.is_leaf()) {
             for (auto& child: p.children) {
-                if(!refine_links(*child.get())) {
-                    done = false;
+                if(refine_links(*child.get())) {
+                    refined = true;
                 }
             }
         }
@@ -513,12 +513,12 @@ private:
         // TODO: Avoid the copy
         std::vector<Linknode> links = p.gathering_from;
         for (auto& link: links) {
-            if (!refine_link(p, link)) {
-                done = false;
+            if (refine_link(p, link)) {
+                refined = true;
             }
         }
 
-        return done;
+        return refined;
     }
 
     /**
@@ -529,7 +529,7 @@ private:
      * @return true if a link has been refined.
      */
     bool refine_link(Quadnode& p, Linknode& link_node) {
-        bool no_subdivision = true;
+        bool refined = false;
 
         // Shooter node p
         Quadnode& q = *link_node.q;
@@ -541,7 +541,7 @@ private:
         //std::cerr << oracle << std::endl;
         if (oracle.r > BF_eps_ || oracle.g > BF_eps_ || oracle.b > BF_eps_) {
             std::cerr << "Refine link.." << std::endl;
-            no_subdivision = false;
+            refined = true;
 
             float F_pq = link_node.form_factor;
             float F_qp = F_pq * tri_p.area() / tri_q.area();
@@ -569,7 +569,7 @@ private:
                 } else {
                     // We could not subdivide so relink
                     link(p, q);
-                    no_subdivision = true;
+                    refined = false;
                 }
             } else {
                 if (subdivide(q)) {
@@ -581,11 +581,11 @@ private:
                 } else {
                     // We could not subdivide so relink
                     link(p, q);
-                    no_subdivision = true;
+                    refined = false;
                 }
             }
         }
-        return no_subdivision;
+        return refined;
     }
 
     void gather_radiosity(Quadnode& in) {

--- a/lib/hierarchical.h
+++ b/lib/hierarchical.h
@@ -524,63 +524,63 @@ private:
     /**
      * Refine link of receiver node p.
      *
-     * @param q receiver node
+     * @param p receiver node
      * @param link link between shooter and receiver node
      * @return true if a link has been refined.
      */
-    bool refine_link(Quadnode& q, Linknode& link_node) {
+    bool refine_link(Quadnode& p, Linknode& link_node) {
         bool no_subdivision = true;
 
         // Shooter node p
-        Quadnode& p = *link_node.q;
+        Quadnode& q = *link_node.q;
 
-        const Triangle& tri_q = get_triangle(q);
         const Triangle& tri_p = get_triangle(p);
+        const Triangle& tri_q = get_triangle(q);
 
-        auto oracle = p.rad_shoot * tri_p.area() * link_node.form_factor;
+        auto oracle = q.rad_shoot * tri_q.area() * link_node.form_factor;
         //std::cerr << oracle << std::endl;
         if (oracle.r > BF_eps_ || oracle.g > BF_eps_ || oracle.b > BF_eps_) {
             std::cerr << "Refine link.." << std::endl;
             no_subdivision = false;
 
-            float F_qp = link_node.form_factor;
-            float F_pq = F_qp * tri_q.area() / tri_p.area();
+            float F_pq = link_node.form_factor;
+            float F_qp = F_pq * tri_p.area() / tri_q.area();
 
             // Remove p from q's gather nodes. It's safe because we are
             // iterating over it's copy.
             // TODO: Make gather_from an unordered set for fast delete.
             std::cerr << "Remove link." << std::endl;
-            for (auto it = q.gathering_from.begin(); it != q.gathering_from.end();) {
-                if (it->q->tri_id == p.tri_id) {
-                    it = q.gathering_from.erase(it);
+            for (auto it = p.gathering_from.begin(); it != p.gathering_from.end();) {
+                if (it->q->tri_id == q.tri_id) {
+                    it = p.gathering_from.erase(it);
                 } else {
                     ++it;
                 }
             }
 
             // Decide which side to subdivide. See refine()
-            if (F_qp < F_pq) {
-                if (subdivide(q)) {
-                    // We've subdivided reciever node q. So all children of q
-                    // should gather from p now.
-                    for (auto& child : q.children) {
-                        link(*child.get(), p);
+            if (F_pq < F_qp) {
+                if (subdivide(p)) {
+                    // We've subdivided reciever node p. So all children of p
+                    // should gather from q now.
+                    for (auto& child : p.children) {
+                        link(*child.get(), q);
                     }
                 } else {
                     // We could not subdivide so relink
-                    link(q, p);
+                    link(p, q);
                     no_subdivision = true;
                 }
             } else {
-                if (subdivide(p)) {
-                    // We've subdivided shooter node p. So receiver node q
-                    // should gather from all children of p now.
-                    for (auto& child : p.children) {
-                        link(q, *child.get());
+                if (subdivide(q)) {
+                    // We've subdivided shooter node q. So receiver node p
+                    // should gather from all children of q now.
+                    for (auto& child : q.children) {
+                        link(p, *child.get());
                     }
                 } else {
                     // We could not subdivide so relink
-                    link(q, p);
+                    link(p, q);
                     no_subdivision = true;
                 }
             }

--- a/lib/hierarchical.h
+++ b/lib/hierarchical.h
@@ -479,21 +479,20 @@ private:
 
     /**
      * Refine all links in all nodes.
-     * @return true if a link has been refined.
+     * @return true if at least one link has been refined.
      */
     bool refine_links() {
         bool refined = false;
         for (auto& p : nodes_) {
-            if(refine_links(p)) {
-                refined = true;
-            }
+            refined |= refine_links(p);
         }
+
         return refined;
     }
 
     /**
      * Refine all links in node p.
-     * @return true if a link has been refined.
+     * @return true if at least one link has been refined.
      */
     bool refine_links(Quadnode& p) {
         bool refined = false;
@@ -501,9 +500,7 @@ private:
         // Process all child nodes first.
         if (!p.is_leaf()) {
             for (auto& child: p.children) {
-                if(refine_links(*child.get())) {
-                    refined = true;
-                }
+                refined |= refine_links(*child.get());
             }
         }
 
@@ -516,8 +513,9 @@ private:
         while (i < size) {
             if (refine_link(p, links[i])) {
                 links.erase(links.begin() + i);
-                refined = true;
                 --size;
+
+                refined |= true;
             } else {
                 ++i;
             }

--- a/radiosity.cpp
+++ b/radiosity.cpp
@@ -392,6 +392,8 @@ Options:
   --form-factor-eps=<float>         Link when form factor estimate is below
                                     [default: 0.04].
                                     Hierarchical radiosity only.
+  --rad-shoot-eps=<float>           Refine link when shooting radiosity times
+                                    form factor is too high [default: 1e-6].
   --max-subdivisions=<int>          Maximum number of subdivisions for smallest
                                     triangle [default: 3].
   --max-iterations=<int>            Maximum iterations to solve system
@@ -473,7 +475,10 @@ int main(int argc, char const* argv[]) {
         size_t max_iterations = args["--max-iterations"].asLong();
         std::cerr << "Maximum iterations: " << max_iterations << std::endl;
 
-        HierarchicalRadiosity model(tree, F_eps, min_area, max_iterations);
+        float BF_eps = std::stof(args["--rad-shoot-eps"].asString());
+        std::cerr << "Shooting radiosity epsilon: " << BF_eps << std::endl;
+
+        HierarchicalRadiosity model(tree, F_eps, min_area, max_iterations, BF_eps);
         model.compute();
 
         KDTree refined_tree(model.triangles());


### PR DESCRIPTION
Render with
```
radiosity hierarchical -w640 -e50 \
  --form-factor-eps=0.1 --rad-shoot-eps=1e-6 \
  --max-iterations=1000 scenes/cornell_box.blend
```

Links are refined according to CW p. 186.

There are some obvious issues:
* ~The recursive call of refine_links on children nodes will process links that
  just have been refined without and intermediate solve system step.~
* ~We always recalculate the form factors even if we do not subdivide further.~
* ~Lots of recursion and copying could be avoided.~