### PR TITLE
Refactor configuration from scratch.

### DIFF
--- a/config.h
+++ b/config.h
@@ -145,10 +145,12 @@ struct RadiosityConfig : public Config {
     enum Mode { EXACT, HIERARCHICAL } mode;
 
     // radiosity parameters
-    float F_eps = 0.04;
-    float BF_eps = 1e-6;
+    float F_eps = 0.04;  // form factor epsilon
+    float BF_eps = 1e-6; // shoot radiosity epsilon
+    // max number of allowed subdivision of a trinagle
     size_t max_subdivisions = 3;
-    size_t max_iterations = 3;
+    size_t max_iterations = 3; // max number of iterations in push-pull solver
+    // minimal area of a triangle (no subdivision if the triangle area is less)
     float min_area = 1. / pow(4, max_subdivisions);
 
     // flags

--- a/config.h
+++ b/config.h
@@ -1,0 +1,216 @@
+#pragma once
+
+#include "lib/types.h"
+
+#include <docopt/docopt.h>
+
+#include <map>
+#include <sstream>
+
+/**
+ * Common configuration
+ */
+struct Config {
+    // image
+    float aspect = 1;
+    size_t width = 640;
+
+    // common options
+    size_t num_threads = 1;
+    float inverse_gamma = 0.454545;
+    float exposure = 1;
+    Color bg_color;
+    bool gamma_correction_enabled = true;
+
+    // scene
+    std::string filename;
+
+    void check() const {
+        assert(0 < aspect);
+        assert(1 <= num_threads);
+        assert(0 <= exposure);
+    }
+
+    /**
+     * Parse color from string.
+     *
+     * @param  color_str contains either
+     *         1. one numerical value in [0, 255], or
+     *         2. three space-separated numerical values in [0, 255].
+     * @return if color_str is of type 1, then return Color with constant value
+     *         for all three channels, otherwise Color with channels containing
+     *         corresponding parsed values.
+     */
+    static Color parse_color(const std::string& color_str) {
+        std::vector<float> result;
+        std::stringstream ss(color_str);
+        std::string item;
+        while (std::getline(ss, item, ' ')) {
+            result.push_back(std::stof(item));
+        }
+
+        if (result.size() == 1) {
+            return Color{result[0], result[0], result[0], 1};
+        } else if (result.size() == 3) {
+            return Color{result[0], result[1], result[2], 1};
+        }
+        assert(false);
+        return {};
+    }
+
+    static Config
+    from_docopt(const std::map<std::string, docopt::value>& args) {
+        Config conf;
+
+        conf.width = args.at("--width").asLong();
+        if (args.at("--aspect")) {
+            conf.aspect = std::stof(args.at("--aspect").asString());
+        }
+
+        conf.num_threads = args.at("--threads").asLong();
+        conf.inverse_gamma = std::stof(args.at("--inverse-gamma").asString());
+        conf.exposure = std::stof(args.at("--exposure").asString());
+        conf.bg_color = parse_color(args.at("--background").asString());
+        conf.gamma_correction_enabled =
+            !args.at("--no-gamma-correction").asBool();
+
+        conf.filename = args.at("<filename>").asString();
+
+        conf.check();
+        return conf;
+    }
+};
+
+/**
+ * Configuration of raycaster, raytracer and pathtracer.
+ */
+struct TracerConfig : public Config {
+    TracerConfig(const Config& common_conf) : Config(common_conf) {}
+
+    // common tracer options
+    int max_recursion_depth = 3;
+
+    // raycaster options
+    float max_visibility = 2;
+
+    // raytracer options
+    float shadow_intensity = 0.5;
+
+    // pathtracer options
+    int num_pixel_samples = 1;
+    int num_monte_carlo_samples = 1;
+
+    void check() const {
+        Config::check();
+        assert(0 < max_recursion_depth);
+        assert(0 <= max_visibility);
+        assert(0 <= shadow_intensity && shadow_intensity <= 1);
+        assert(1 <= num_pixel_samples);
+        assert(0 <= num_monte_carlo_samples);
+    }
+
+    static TracerConfig
+    from_docopt(const std::map<std::string, docopt::value>& args) {
+        TracerConfig conf(Config::from_docopt(args));
+
+        if (args.count("--max-depth")) {
+            conf.max_recursion_depth = args.at("--max-depth").asLong();
+        }
+        if (args.count("--max-visibility")) {
+            conf.max_visibility =
+                std::stof(args.at("--max-visibility").asString());
+        }
+        if (args.count("--shadow")) {
+            conf.shadow_intensity = std::stof(args.at("--shadow").asString());
+        }
+        if (args.count("--pixel-samples")) {
+            conf.num_pixel_samples = args.at("--pixel-samples").asLong();
+        }
+        if (args.count("--monte-carlo-samples")) {
+            conf.num_monte_carlo_samples =
+                args.at("--monte-carlo-samples").asLong();
+        }
+
+        conf.check();
+        return conf;
+    }
+};
+
+/**
+ * Radiosity configuration.
+ */
+struct RadiosityConfig : public Config {
+    RadiosityConfig(const Config& conf) : Config(conf) {}
+
+    enum Mode { EXACT, HIERARCHICAL } mode;
+
+    // radiosity parameters
+    float F_eps = 0.04;
+    float BF_eps = 1e-6;
+    size_t max_subdivisions = 3;
+    size_t max_iterations = 3;
+    float min_area = 1. / pow(4, max_subdivisions);
+
+    // flags
+    bool gouraud_enabled = false;
+    enum Mesh { NO_MESH, SIMPLE_MESH, FEATURE_MESH } mesh = NO_MESH;
+    bool features_mesh_enabled = false;
+    bool links_enabled = false;
+    bool exact_hierarchical_enabled = false;
+
+    void check() const {
+        Config::check();
+        assert(0 < F_eps);
+        assert(0 < BF_eps);
+        assert(0 < min_area);
+    }
+
+    static RadiosityConfig
+    from_docopt(const std::map<std::string, docopt::value>& args) {
+        RadiosityConfig conf(Config::from_docopt(args));
+
+        conf.mode = args.at("exact").asBool() ? EXACT : HIERARCHICAL;
+        assert(args.at("hierarchical").asBool() == !args.at("exact").asBool());
+
+        // radiosity parameters
+        if (args.count("--form-factor-eps")) {
+            conf.F_eps = std::stof(args.at("--form-factor-eps").asString());
+        }
+        if (args.count("--rad-shoot-eps")) {
+            conf.BF_eps = std::stof(args.at("--rad-shoot-eps").asString());
+        }
+        if (args.count("--max-subdivisions")) {
+            conf.max_subdivisions =
+                std::stof(args.at("--max-subdivisions").asString());
+        }
+        if (args.count("--max-iterations")) {
+            conf.max_iterations =
+                std::stof(args.at("--max-iterations").asString());
+        }
+
+        // extra options
+        if (args.count("--gouraud")) {
+            conf.gouraud_enabled = args.at("--gouraud").asBool();
+        }
+        if (args.count("--mesh")) {
+            if (!args.at("--mesh")) {
+                conf.mesh = NO_MESH;
+            } else if (args.at("--mesh").asString() == "simple") {
+                conf.mesh = SIMPLE_MESH;
+            } else if (args.at("--mesh").asString() == "feature") {
+                conf.mesh = FEATURE_MESH;
+            } else {
+                assert(!"wrong mesh option");
+            }
+        }
+        if (args.count("--links")) {
+            conf.links_enabled = args.at("--links").asBool();
+        }
+        if (args.count("--exact")) {
+            conf.exact_hierarchical_enabled = args.at("--exact").asBool();
+        }
+
+        conf.check();
+        return conf;
+    }
+};

--- a/pathtracer.cpp
+++ b/pathtracer.cpp
@@ -1,3 +1,4 @@
+#include "pathtracer.h"
 #include "lib/lambertian.h"
 #include "lib/output.h"
 #include "lib/sampling.h"
@@ -11,10 +12,10 @@
  * equation, thefore it is not guaranteed that the calculated color values are
  * less than 1. E.g. an approximation of value 1 may be greater than 1.
  */
-Color trace(const Vec& origin, const Vec& dir, const Tree& triangles,
+Color trace(const Vec& origin, const Vec& dir, const KDTree& triangles,
             const std::vector<Light>& lights, int depth,
-            const Configuration& conf) {
-    if (depth > conf.max_depth) {
+            const TracerConfig& conf) {
+    if (depth > conf.max_recursion_depth) {
         return {};
     }
 

--- a/pathtracer.cpp
+++ b/pathtracer.cpp
@@ -1,6 +1,5 @@
 #include "pathtracer.h"
 #include "lib/lambertian.h"
-#include "lib/output.h"
 #include "lib/sampling.h"
 #include "lib/stats.h"
 #include "trace.h"

--- a/pathtracer.h
+++ b/pathtracer.h
@@ -1,0 +1,24 @@
+#pragma once
+
+extern const char* USAGE;
+const char* USAGE =
+    R"(Usage: pathtracer <filename> [options]
+
+Options:
+  -w --width=<px>                   Width of the image [default: 640].
+  -a --aspect=<num>                 Aspect ratio of the image. If the model has
+                                    specified the aspect ratio, it will be used
+                                    [default: 1].
+  --background=<3x float>           Background color [default: 0 0 0].
+  -t --threads=<int>                Number of threads [default: 1].
+  --inverse-gamma=<float>           Inverse of gamma for gamma correction
+                                    [default: 0.454545].
+  --no-gamma-correction             Disables gamma correction.
+  --exposure=<float>                Exposure [default: 1].
+
+Pathtracer options:
+  -d --max-depth=<int>              Maximum recursion depth for raytracing
+                                    [default: 3].
+  -p --pixel-samples=<int>          Number of samples per pixel [default: 1].
+  -m --monte-carlo-samples=<int>    Monto Carlo samples per ray [default: 8].
+)";

--- a/radiosity.cpp
+++ b/radiosity.cpp
@@ -223,14 +223,12 @@ Image raycast(const KDTree& tree, const RadiosityConfig& conf,
         tasks.emplace_back(
             pool.enqueue([&image, &cam, &tree, &radiosity, y, &conf]() {
                 for (size_t x = 0; x < image.width(); ++x) {
-                    for (int i = 0; i < 1; ++i) { // TODO
-                        auto cam_dir = cam.raster2cam(
-                            aiVector2D(x, y), image.width(), image.height());
+                    auto cam_dir = cam.raster2cam(
+                        aiVector2D(x, y), image.width(), image.height());
 
-                        Stats::instance().num_prim_rays += 1;
-                        image(x, y) += trace(cam.mPosition, cam_dir, tree,
-                                             radiosity, conf);
-                    }
+                    Stats::instance().num_prim_rays += 1;
+                    image(x, y) +=
+                        trace(cam.mPosition, cam_dir, tree, radiosity, conf);
 
                     image(x, y) = exposure(image(x, y), conf.exposure);
 
@@ -275,26 +273,24 @@ Image raycast(const KDTree& tree, const RadiosityConfig& conf,
         tasks.emplace_back(pool.enqueue([&image, &cam, &tree, &mesh, &frad,
                                          &vrad, y, &conf]() {
             for (size_t x = 0; x < image.width(); ++x) {
-                for (int i = 0; i < 1; ++i) { // TODO
-                    auto cam_dir = cam.raster2cam(
-                        aiVector2D(x, y), image.width(), image.height());
+                auto cam_dir = cam.raster2cam(aiVector2D(x, y), image.width(),
+                                              image.height());
 
-                    Stats::instance().num_prim_rays += 1;
+                Stats::instance().num_prim_rays += 1;
 
-                    if (!conf.gouraud_enabled) {
-                        image(x, y) += trace(cam.mPosition, cam_dir, tree, mesh,
-                                             frad, conf);
-                    } else {
-                        image(x, y) += trace_gouraud(cam.mPosition, cam_dir,
-                                                     tree, mesh, vrad, conf);
-                    }
+                if (!conf.gouraud_enabled) {
+                    image(x, y) +=
+                        trace(cam.mPosition, cam_dir, tree, mesh, frad, conf);
+                } else {
+                    image(x, y) += trace_gouraud(cam.mPosition, cam_dir, tree,
+                                                 mesh, vrad, conf);
+                }
 
-                    image(x, y) = exposure(image(x, y), conf.exposure);
+                image(x, y) = exposure(image(x, y), conf.exposure);
 
-                    // gamma correction
-                    if (conf.gamma_correction_enabled) {
-                        image(x, y) = gamma(image(x, y), conf.inverse_gamma);
-                    }
+                // gamma correction
+                if (conf.gamma_correction_enabled) {
+                    image(x, y) = gamma(image(x, y), conf.inverse_gamma);
                 }
             }
         }));

--- a/radiosity.cpp
+++ b/radiosity.cpp
@@ -1,4 +1,5 @@
-#include "lib/radiosity.h"
+#include "radiosity.h"
+#include "config.h"
 #include "lib/algorithm.h"
 #include "lib/effects.h"
 #include "lib/hierarchical.h"
@@ -7,6 +8,7 @@
 #include "lib/mesh.h"
 #include "lib/output.h"
 #include "lib/progress_bar.h"
+#include "lib/radiosity.h"
 #include "lib/range.h"
 #include "lib/raster.h"
 #include "lib/runtime.h"
@@ -31,8 +33,8 @@
 #include <unordered_set>
 #include <vector>
 
-Color trace(const Vec& origin, const Vec& dir, const Tree& tree,
-            const std::vector<Color>& radiosity, const Configuration& conf) {
+Color trace(const Vec& origin, const Vec& dir, const KDTree& tree,
+            const std::vector<Color>& radiosity, const RadiosityConfig& conf) {
     Stats::instance().num_rays += 1;
 
     // intersection
@@ -46,9 +48,9 @@ Color trace(const Vec& origin, const Vec& dir, const Tree& tree,
     return radiosity[triangle_id];
 }
 
-Color trace(const Vec& origin, const Vec& dir, const Tree& tree,
+Color trace(const Vec& origin, const Vec& dir, const KDTree& tree,
             const RadiosityMesh& mesh, const FaceRadiosityHandle& rad,
-            const Configuration& conf) {
+            const RadiosityConfig& conf) {
     Stats::instance().num_rays += 1;
 
     // intersection
@@ -63,10 +65,10 @@ Color trace(const Vec& origin, const Vec& dir, const Tree& tree,
     return mesh.property(rad, face);
 }
 
-Color trace_gouraud(const Vec& origin, const Vec& dir, const Tree& tree,
+Color trace_gouraud(const Vec& origin, const Vec& dir, const KDTree& tree,
                     const RadiosityMesh& mesh,
                     const VertexRadiosityHandle& vrad,
-                    const Configuration& conf) {
+                    const RadiosityConfig& conf) {
     Stats::instance().num_rays += 1;
 
     // intersection
@@ -95,7 +97,7 @@ Color trace_gouraud(const Vec& origin, const Vec& dir, const Tree& tree,
     return rad;
 }
 
-std::vector<Color> compute_radiosity(const Tree& tree) {
+std::vector<Color> compute_radiosity(const KDTree& tree) {
     using MatrixF = math::Matrix<float>;
     using VectorF = math::Vector<float>;
     size_t num_triangles = tree.num_triangles();
@@ -212,8 +214,9 @@ Triangles triangles_from_scene(const aiScene* scene) {
     return triangles;
 }
 
-Image raycast(const KDTree& tree, const Configuration& conf, const Camera& cam,
-              const std::vector<Color>& radiosity, Image&& image) {
+Image raycast(const KDTree& tree, const RadiosityConfig& conf,
+              const Camera& cam, const std::vector<Color>& radiosity,
+              Image&& image) {
     Runtime rt(Stats::instance().runtime_ms);
 
     std::cerr << "Rendering          ";
@@ -225,7 +228,7 @@ Image raycast(const KDTree& tree, const Configuration& conf, const Camera& cam,
         tasks.emplace_back(
             pool.enqueue([&image, &cam, &tree, &radiosity, y, &conf]() {
                 for (size_t x = 0; x < image.width(); ++x) {
-                    for (int i = 0; i < conf.num_pixel_samples; ++i) {
+                    for (int i = 0; i < 1; ++i) { // TODO
                         auto cam_dir = cam.raster2cam(
                             aiVector2D(x, y), image.width(), image.height());
 
@@ -256,8 +259,8 @@ Image raycast(const KDTree& tree, const Configuration& conf, const Camera& cam,
     return image;
 }
 
-Image raycast(const KDTree& tree, const Configuration& conf, const Camera& cam,
-              const RadiosityMesh& mesh, Image&& image) {
+Image raycast(const KDTree& tree, const RadiosityConfig& conf,
+              const Camera& cam, const RadiosityMesh& mesh, Image&& image) {
     Runtime rt(Stats::instance().runtime_ms);
 
     std::cerr << "Rendering          ";
@@ -277,13 +280,13 @@ Image raycast(const KDTree& tree, const Configuration& conf, const Camera& cam,
         tasks.emplace_back(pool.enqueue([&image, &cam, &tree, &mesh, &frad,
                                          &vrad, y, &conf]() {
             for (size_t x = 0; x < image.width(); ++x) {
-                for (int i = 0; i < conf.num_pixel_samples; ++i) {
+                for (int i = 0; i < 1; ++i) { // TODO
                     auto cam_dir = cam.raster2cam(
                         aiVector2D(x, y), image.width(), image.height());
 
                     Stats::instance().num_prim_rays += 1;
 
-                    if (!conf.rad_gouraud_enabled) {
+                    if (!conf.gouraud_enabled) {
                         image(x, y) += trace(cam.mPosition, cam_dir, tree, mesh,
                                              frad, conf);
                     } else {
@@ -321,7 +324,7 @@ Image raycast(const KDTree& tree, const Configuration& conf, const Camera& cam,
     return image;
 }
 
-Image render_feature_lines(const KDTree& tree, const Configuration& conf,
+Image render_feature_lines(const KDTree& tree, const RadiosityConfig& conf,
                            const Camera& cam, Image&& image) {
     // Render feature lines after
     // "Ray Tracing NPR-Style Feature Lines" by Choudhury and Parker.
@@ -458,56 +461,16 @@ Image render_radiosity_mesh(const RadiosityMesh& mesh, const Camera& cam,
     return image;
 }
 
-static const char USAGE[] =
-    R"(Usage: radiosity (direct|hierarchical) <filename> [options]
-
-Options:
-  -w --width=<px>                   Width of the image [default: 640].
-  -a --aspect=<num>                 Aspect ratio of the image. If the model has
-                                    specified the aspect ratio, it will be
-                                    used. Otherwise default value is 1.
-  --background=<3x float>           Background color [default: 0 0 0].
-  -t --threads=<int>                Number of threads [default: 1].
-  --inverse-gamma=<float>           Inverse of gamma for gamma correction
-                                    [default: 0.454545].
-  --no-gamma-correction             Disables gamma correction.
-  -e --exposure=<float>             Exposure of the image [default: 1.0].
-  --rad-simple-mesh                 Render mesh without depth overlapping.
-  --rad-features-mesh               Render mesh of features.
-  --rad-links                       Render hierarchical radiosity links.
-  --rad-exact                       Render hierarchical mesh with exact
-                                    radiosity solution.
-  --gouraud                         Enable gouraud shading [default: false].
-  --form-factor-eps=<float>         Link when form factor estimate is below
-                                    [default: 0.04].
-                                    Hierarchical radiosity only.
-  --rad-shoot-eps=<float>           Refine link when shooting radiosity times
-                                    form factor is too high [default: 1e-6].
-  --max-subdivisions=<int>          Maximum number of subdivisions for smallest
-                                    triangle [default: 3].
-  --max-iterations=<int>            Maximum iterations to solve system
-                                    [default: 1000].
-)";
-
 int main(int argc, char const* argv[]) {
-    // parameters
-    std::map<std::string, docopt::value> args =
-        docopt::docopt(USAGE, {argv + 1, argv + argc}, true, "radiosity");
+    RadiosityConfig conf = RadiosityConfig::from_docopt(
+        docopt::docopt(USAGE, {argv + 1, argv + argc}, true, "radiosity"));
 
-    Configuration conf{1, 0, 1, 0 // unused configuration arguments
-                       ,
-                       args["--threads"].asLong(),
-                       args["--background"].asString(),
-                       std::stof(args["--inverse-gamma"].asString()),
-                       args["--no-gamma-correction"].asBool(), 1,
-                       std::stof(args["--exposure"].asString())};
-
-    conf.rad_gouraud_enabled = args["--gouraud"].asBool();
+    std::cerr << conf.exposure << std::endl;
 
     // import scene
     Assimp::Importer importer;
     const aiScene* scene =
-        importer.ReadFile(args["<filename>"].asString().c_str(),
+        importer.ReadFile(conf.filename.c_str(),
                           aiProcess_CalcTangentSpace | aiProcess_Triangulate |
                               aiProcess_JoinIdenticalVertices |
                               aiProcess_GenNormals | aiProcess_SortByPType);
@@ -520,11 +483,10 @@ int main(int argc, char const* argv[]) {
     // setup camera
     assert(scene->mNumCameras == 1); // we can deal only with a single camera
     auto& sceneCam = *scene->mCameras[0];
-    if (args["--aspect"]) {
-        sceneCam.mAspect = std::stof(args["--aspect"].asString());
-        assert(sceneCam.mAspect > 0);
-    } else if (sceneCam.mAspect == 0) {
-        sceneCam.mAspect = 1.f;
+    if (sceneCam.mAspect == 0) {
+        sceneCam.mAspect = conf.aspect;
+    } else {
+        conf.aspect = sceneCam.mAspect;
     }
     auto* camNode = scene->mRootNode->FindNode(sceneCam.mName);
     assert(camNode != nullptr);
@@ -536,7 +498,7 @@ int main(int argc, char const* argv[]) {
     KDTree tree(std::move(triangles));
 
     // Image
-    int width = args["--width"].asLong();
+    int width = conf.width;
     assert(width > 0);
     int height = width / cam.mAspect;
     Image image(width, height);
@@ -544,33 +506,26 @@ int main(int argc, char const* argv[]) {
     // Compute radiosity
     std::vector<Color> radiosity;
 
-    if (args["direct"].asBool()) {
+    // TODO: split in functions
+    if (conf.mode == RadiosityConfig::EXACT) {
         radiosity = compute_radiosity(tree);
         image = raycast(tree, conf, cam, radiosity, std::move(image));
-        if (args["--rad-simple-mesh"] && args["--rad-simple-mesh"].asBool()) {
+        if (conf.mesh == RadiosityConfig::SIMPLE_MESH) {
             image = render_mesh(tree.triangles(), cam, std::move(image));
-        } else {
+        } else if (conf.mesh == RadiosityConfig::FEATURE_MESH) {
             image = render_feature_lines(tree, conf, cam, std::move(image));
         }
-    } else if (args["hierarchical"].asBool()) {
-        // compute minimal area
-        int max_subdivisions = args["--max-subdivisions"].asLong();
-        float min_area = ::min(tree.triangles().begin(), tree.triangles().end(),
-                               [](const Triangle& tri) { return tri.area(); });
-        min_area /= pow(4, max_subdivisions);
-        std::cerr << "Minimal area: " << min_area << std::endl;
+    } else if (conf.mode == RadiosityConfig::HIERARCHICAL) {
+        conf.min_area = ::min(tree.triangles().begin(), tree.triangles().end(),
+                              [](const Triangle& tri) { return tri.area(); });
+        conf.min_area /= pow(4, conf.max_subdivisions);
+        std::cerr << "Minimal area: " << conf.min_area << std::endl;
+        std::cerr << "Form factor epsilon: " << conf.F_eps << std::endl;
+        std::cerr << "Maximum iterations: " << conf.max_iterations << std::endl;
+        std::cerr << "Shooting radiosity epsilon: " << conf.BF_eps << std::endl;
 
-        float F_eps = std::stof(args["--form-factor-eps"].asString());
-        std::cerr << "Form factor epsilon: " << F_eps << std::endl;
-
-        size_t max_iterations = args["--max-iterations"].asLong();
-        std::cerr << "Maximum iterations: " << max_iterations << std::endl;
-
-        float BF_eps = std::stof(args["--rad-shoot-eps"].asString());
-        std::cerr << "Shooting radiosity epsilon: " << BF_eps << std::endl;
-
-        HierarchicalRadiosity model(tree, F_eps, min_area, BF_eps,
-                                    max_iterations);
+        HierarchicalRadiosity model(tree, conf.F_eps, conf.min_area,
+                                    conf.BF_eps, conf.max_iterations);
         try {
             model.compute();
         } catch (std::runtime_error e) {
@@ -584,7 +539,7 @@ int main(int argc, char const* argv[]) {
         Stats::instance().num_triangles = refined_tree.num_triangles();
         Stats::instance().kdtree_height = refined_tree.height();
 
-        if (args["--rad-exact"] && args["--rad-exact"].asBool()) {
+        if (conf.exact_hierarchical_enabled) {
             radiosity = compute_radiosity(refined_tree);
             image =
                 raycast(refined_tree, conf, cam, radiosity, std::move(image));
@@ -593,21 +548,15 @@ int main(int argc, char const* argv[]) {
                             std::move(image));
         }
 
-        if (args["--rad-simple-mesh"] && args["--rad-simple-mesh"].asBool()) {
-            image =
-                render_mesh(refined_tree.triangles(), cam, std::move(image));
-        } else if (args["--rad-features-mesh"] &&
-                   args["--rad-features-mesh"].asBool()) {
-            image =
-                render_feature_lines(refined_tree, conf, cam, std::move(image));
+        if (conf.mesh == RadiosityConfig::SIMPLE_MESH) {
+            image = render_mesh(tree.triangles(), cam, std::move(image));
+        } else if (conf.mesh == RadiosityConfig::FEATURE_MESH) {
+            image = render_feature_lines(tree, conf, cam, std::move(image));
         }
 
-        if (args["--rad-links"] && args["--rad-links"].asBool()) {
+        if (conf.links_enabled) {
             image = model.visualize_links(cam, std::move(image));
         }
-    } else {
-        assert(!"parsed arguments");
-        throw std::logic_error("parsed arguments");
     }
 
     // output stats

--- a/radiosity.cpp
+++ b/radiosity.cpp
@@ -1,9 +1,7 @@
 #include "radiosity.h"
 #include "config.h"
-#include "lib/algorithm.h"
 #include "lib/effects.h"
 #include "lib/hierarchical.h"
-#include "lib/lambertian.h"
 #include "lib/matrix.h"
 #include "lib/mesh.h"
 #include "lib/output.h"
@@ -12,7 +10,6 @@
 #include "lib/range.h"
 #include "lib/raster.h"
 #include "lib/runtime.h"
-#include "lib/sampling.h"
 #include "lib/stats.h"
 #include "lib/triangle.h"
 #include "lib/xorshift.h"
@@ -25,11 +22,9 @@
 #include <docopt/docopt.h>
 
 #include <array>
-#include <chrono>
 #include <iostream>
 #include <map>
 #include <math.h>
-#include <stack>
 #include <unordered_set>
 #include <vector>
 
@@ -464,8 +459,6 @@ Image render_radiosity_mesh(const RadiosityMesh& mesh, const Camera& cam,
 int main(int argc, char const* argv[]) {
     RadiosityConfig conf = RadiosityConfig::from_docopt(
         docopt::docopt(USAGE, {argv + 1, argv + argc}, true, "radiosity"));
-
-    std::cerr << conf.exposure << std::endl;
 
     // import scene
     Assimp::Importer importer;

--- a/radiosity.h
+++ b/radiosity.h
@@ -1,0 +1,38 @@
+#pragma once
+
+static const char* USAGE =
+    R"(Usage:
+  radiosity (exact|hierarchical) [options] <filename>
+
+Options:
+  -w --width=<px>               Width of the image [default: 640].
+  -a --aspect=<num>             Aspect ratio of the image. If the model has
+                                specified the aspect ratio, it will be
+                                used. Otherwise default value is 1.
+  --background=<3x float>       Background color [default: 0 0 0].
+  -t --threads=<int>            Number of threads [default: 1].
+  --inverse-gamma=<float>       Inverse of gamma for gamma correction
+                                [default: 0.454545].
+  --no-gamma-correction         Disables gamma correction.
+  -e --exposure=<float>         Exposure of the image [default: 1.0].
+
+Hierarchical radiosity options:
+  --form-factor-eps=<float>     Link when form factor estimate is below
+                                [default: 0.04].
+  --rad-shoot-eps=<float>       Refine link when shooting radiosity times
+                                form factor is too high [default: 1e-6].
+  --max-subdivisions=<int>      Maximum number of subdivisions for smallest
+                                triangle [default: 3].
+  --max-iterations=<int>        Maximum iterations to solve system [default: 3].
+
+Radiosity options:
+  -g --gouraud                  Enable gouraud shading for hierarchical
+                                radiosity.
+  --mesh=<simple|feature>       Render mesh either without taking depth of
+                                objects into account (simple), which is fast, or
+                                by computing the correct overlapping (feature),
+                                which is slow.
+  --links                       Render hierarchical radiosity links.
+  --exact                       Render hierarchical mesh with exact radiosity
+                                solution. For debugging only.
+)";

--- a/raycaster.cpp
+++ b/raycaster.cpp
@@ -1,3 +1,5 @@
+#include "raycaster.h"
+#include "config.h"
 #include "lib/intersection.h"
 #include "lib/lambertian.h"
 #include "lib/raster.h"
@@ -13,9 +15,9 @@
 #include <math.h>
 #include <vector>
 
-Color trace(const Vec& origin, const Vec& dir, const Tree& triangles,
+Color trace(const Vec& origin, const Vec& dir, const KDTree& triangles,
             const std::vector<Light>& /* lights */, int /* depth */,
-            const Configuration& conf) {
+            const TracerConfig& conf) {
     // intersection
     float dist_to_triangle, s, t;
     auto triangle_id =

--- a/raycaster.cpp
+++ b/raycaster.cpp
@@ -1,19 +1,8 @@
 #include "raycaster.h"
 #include "config.h"
-#include "lib/intersection.h"
-#include "lib/lambertian.h"
-#include "lib/raster.h"
 #include "lib/stats.h"
 #include "lib/triangle.h"
 #include "trace.h"
-
-#include <assimp/Importer.hpp>  // C++ importer interface
-#include <assimp/postprocess.h> // Post processing flags
-#include <assimp/scene.h>       // Output data structure
-
-#include <iostream>
-#include <math.h>
-#include <vector>
 
 Color trace(const Vec& origin, const Vec& dir, const KDTree& triangles,
             const std::vector<Light>& /* lights */, int /* depth */,

--- a/raycaster.h
+++ b/raycaster.h
@@ -1,0 +1,21 @@
+#pragma once
+
+extern const char* USAGE;
+const char* USAGE =
+    R"(Usage: raycaster <filename> [options]
+
+Options:
+  -w --width=<px>            Width of the image [default: 640].
+  -a --aspect=<num>          Aspect ratio of the image. If the model has
+                             specified the aspect ratio, it will be used
+                             [default: 1].
+  --background=<3x float>    Background color [default: 0 0 0].
+  -t --threads=<int>         Number of threads [default: 1].
+  --inverse-gamma=<float>    Inverse of gamma for gamma correction
+                             [default: 0.454545].
+  --no-gamma-correction      Disables gamma correction.
+  --exposure=<float>         Exposure [default: 1].
+
+Raycaster options:
+  --max-visibility=<float>   Any object farther away is dark [default: 2.0].
+)";

--- a/raytracer.cpp
+++ b/raytracer.cpp
@@ -1,13 +1,14 @@
+#include "raytracer.h"
 #include "lib/lambertian.h"
 #include "lib/stats.h"
 #include "trace.h"
 
-Color trace(const Vec& origin, const Vec& dir, const Tree& triangles_tree,
+Color trace(const Vec& origin, const Vec& dir, const KDTree& triangles_tree,
             const std::vector<Light>& lights, int depth,
-            const Configuration& conf) {
+            const TracerConfig& conf) {
     Stats::instance().num_rays += 1;
 
-    if (depth > conf.max_depth) {
+    if (depth > conf.max_recursion_depth) {
         return {};
     }
 

--- a/raytracer.h
+++ b/raytracer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+extern const char* USAGE;
+const char* USAGE =
+    R"(Usage: raytracer <filename> [options]
+
+Options:
+  -w --width=<px>           Width of the image [default: 640].
+  -a --aspect=<num>         Aspect ratio of the image. If the model has
+                            specified the aspect ratio, it will be used
+                            [default: 1].
+  --background=<3x float>   Background color [default: 0 0 0].
+  -t --threads=<int>        Number of threads [default: 1].
+  --inverse-gamma=<float>   Inverse of gamma for gamma correction
+                            [default: 0.454545].
+  --no-gamma-correction     Disables gamma correction.
+  --exposure=<float>        Exposure [default: 1].
+
+Raytracer options:
+  -d --max-depth=<int>      Maximum recursion depth for raytracing [default: 3].
+  --shadow=<float>          Intensity of shadow [default: 0.5].
+)";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,5 +30,6 @@ foreach (TEST_NAME ${TESTS})
     add_test(${TEST_NAME} ${TEST_NAME})
 endforeach ()
 
+target_link_libraries(test_config ${docopt_LIBRARIES})
 target_link_libraries(test_mesh ${openmesh_LIBRARIES})
 target_link_libraries(test_radiosity ${openmesh_LIBRARIES})

--- a/trace.h
+++ b/trace.h
@@ -1,77 +1,75 @@
 #pragma once
 
+#include "config.h"
 #include "lib/kdtree.h"
 #include "lib/types.h"
 
-#include <sstream>
-#include <vector>
+// #include <sstream>
+// #include <vector>
 
-using Tree = KDTree;
+// using Tree = KDTree;
 
-class Configuration {
-public:
-    Configuration(long max_depth, float shadow_intensity,
-                  long num_pixel_samples, long num_monte_carlo_samples,
-                  long num_threads, const std::string& bg_color_str,
-                  float inverse_gamma, const bool no_gamma_correction,
-                  float max_visibility, float exposure)
-        : max_depth(max_depth)
-        , shadow_intensity(shadow_intensity)
-        , num_pixel_samples(num_pixel_samples)
-        , num_monte_carlo_samples(num_monte_carlo_samples)
-        , num_threads(num_threads)
-        , inverse_gamma(inverse_gamma)
-        , gamma_correction_enabled(!no_gamma_correction)
-        , max_visibility(max_visibility)
-        , exposure(exposure) {
-        check();
+// class Configuration {
+// public:
+//     Configuration(long max_depth, float shadow_intensity,
+//                   long num_pixel_samples, long num_monte_carlo_samples,
+//                   long num_threads, const std::string& bg_color_str,
+//                   float inverse_gamma, const bool no_gamma_correction,
+//                   float max_visibility, float exposure)
+//         : max_depth(max_depth)
+//         , shadow_intensity(shadow_intensity)
+//         , num_pixel_samples(num_pixel_samples)
+//         , num_monte_carlo_samples(num_monte_carlo_samples)
+//         , num_threads(num_threads)
+//         , inverse_gamma(inverse_gamma)
+//         , gamma_correction_enabled(!no_gamma_correction)
+//         , max_visibility(max_visibility)
+//         , exposure(exposure) {
+//         check();
 
-        // Parse background color.
-        std::vector<float> result;
-        std::stringstream ss(bg_color_str);
-        std::string item;
-        while (std::getline(ss, item, ' ')) {
-            result.push_back(std::stof(item));
-        }
+//         // Parse background color.
+//         std::vector<float> result;
+//         std::stringstream ss(bg_color_str);
+//         std::string item;
+//         while (std::getline(ss, item, ' ')) {
+//             result.push_back(std::stof(item));
+//         }
 
-        if (result.size() == 1) {
-            bg_color = Color{result[0], result[0], result[0], 1};
-        } else if (result.size() == 3) {
-            bg_color = Color{result[0], result[1], result[2], 1};
-        } else {
-            assert(false);
-        }
-    }
+//         if (result.size() == 1) {
+//             bg_color = Color{result[0], result[0], result[0], 1};
+//         } else if (result.size() == 3) {
+//             bg_color = Color{result[0], result[1], result[2], 1};
+//         } else {
+//             assert(false);
+//         }
+//     }
 
-private:
-    void check() {
-        assert(0 < max_depth);
-        assert(0 <= shadow_intensity && shadow_intensity <= 1);
-        assert(1 <= num_pixel_samples);
-        assert(0 <= num_monte_carlo_samples);
-        assert(1 <= num_threads);
-        assert(0 <= max_visibility);
-        assert(0 <= exposure);
-    }
+// private:
+//     void check() {
+//         assert(0 < max_depth);
+//         assert(0 <= shadow_intensity && shadow_intensity <= 1);
+//         assert(1 <= num_pixel_samples);
+//         assert(0 <= num_monte_carlo_samples);
+//         assert(1 <= num_threads);
+//         assert(0 <= max_visibility);
+//         assert(0 <= exposure);
+//     }
 
-public:
-    int max_depth;
-    float shadow_intensity;
-    int num_pixel_samples;
-    int num_monte_carlo_samples;
-    int num_threads;
-    float inverse_gamma;
-    bool gamma_correction_enabled;
-    Color bg_color;
-    float max_visibility;
-    float exposure;
+// public:
+//     int max_depth;
+//     float shadow_intensity;
+//     int num_pixel_samples;
+//     int num_monte_carlo_samples;
+//     int num_threads;
+//     float inverse_gamma;
+//     bool gamma_correction_enabled;
+//     Color bg_color;
+//     float max_visibility;
+//     float exposure;
 
-    float rad_gouraud_enabled = false;
-};
+//     float rad_gouraud_enabled = false;
+// };
 
-Color trace(const Vec& origin, const Vec& dir, const Tree& triangles_tree,
+Color trace(const Vec& origin, const Vec& dir, const KDTree& triangles_tree,
             const std::vector<Light>& lights, int depth,
-            const Configuration& conf);
-
-Color trace(const Vec& origin, const Vec& dir, const Tree& triangles_tree,
-            const std::vector<Color>& radiosity, const Configuration& conf);
+            const TracerConfig& conf);

--- a/trace.h
+++ b/trace.h
@@ -4,72 +4,22 @@
 #include "lib/kdtree.h"
 #include "lib/types.h"
 
-// #include <sstream>
-// #include <vector>
-
-// using Tree = KDTree;
-
-// class Configuration {
-// public:
-//     Configuration(long max_depth, float shadow_intensity,
-//                   long num_pixel_samples, long num_monte_carlo_samples,
-//                   long num_threads, const std::string& bg_color_str,
-//                   float inverse_gamma, const bool no_gamma_correction,
-//                   float max_visibility, float exposure)
-//         : max_depth(max_depth)
-//         , shadow_intensity(shadow_intensity)
-//         , num_pixel_samples(num_pixel_samples)
-//         , num_monte_carlo_samples(num_monte_carlo_samples)
-//         , num_threads(num_threads)
-//         , inverse_gamma(inverse_gamma)
-//         , gamma_correction_enabled(!no_gamma_correction)
-//         , max_visibility(max_visibility)
-//         , exposure(exposure) {
-//         check();
-
-//         // Parse background color.
-//         std::vector<float> result;
-//         std::stringstream ss(bg_color_str);
-//         std::string item;
-//         while (std::getline(ss, item, ' ')) {
-//             result.push_back(std::stof(item));
-//         }
-
-//         if (result.size() == 1) {
-//             bg_color = Color{result[0], result[0], result[0], 1};
-//         } else if (result.size() == 3) {
-//             bg_color = Color{result[0], result[1], result[2], 1};
-//         } else {
-//             assert(false);
-//         }
-//     }
-
-// private:
-//     void check() {
-//         assert(0 < max_depth);
-//         assert(0 <= shadow_intensity && shadow_intensity <= 1);
-//         assert(1 <= num_pixel_samples);
-//         assert(0 <= num_monte_carlo_samples);
-//         assert(1 <= num_threads);
-//         assert(0 <= max_visibility);
-//         assert(0 <= exposure);
-//     }
-
-// public:
-//     int max_depth;
-//     float shadow_intensity;
-//     int num_pixel_samples;
-//     int num_monte_carlo_samples;
-//     int num_threads;
-//     float inverse_gamma;
-//     bool gamma_correction_enabled;
-//     Color bg_color;
-//     float max_visibility;
-//     float exposure;
-
-//     float rad_gouraud_enabled = false;
-// };
-
+/**
+ * Main function of a tracer.
+ *
+ * Used in the main routine for tracing (cf. main.cpp).
+ *
+ * TODO: Could be a performance bottleneck since not inlined. Profile!
+ *
+ * @param  origin         origin of the ray
+ * @param  dir            direction of the ray
+ * @param  triangles_tree kd-tree containing triangles for intersection
+ *                        computations
+ * @param  lights         all lights in the scene
+ * @param  depth          recursion depth
+ * @param  conf           configuration
+ * @return                Color hit by the ray
+ */
 Color trace(const Vec& origin, const Vec& dir, const KDTree& triangles_tree,
             const std::vector<Light>& lights, int depth,
             const TracerConfig& conf);

--- a/vendor/docopt/CMakeLists.txt
+++ b/vendor/docopt/CMakeLists.txt
@@ -7,7 +7,7 @@ ExternalProject_Add(
     docopt
     PREFIX ${CMAKE_BINARY_DIR}/vendor/docopt
     GIT_REPOSITORY https://github.com/docopt/docopt.cpp.git
-    GIT_TAG a4177cc
+    GIT_TAG 1811022
     CMAKE_ARGS
     	-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     	-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -19,6 +19,6 @@ ExternalProject_Get_Property(docopt install_dir)
 set(docopt_INCLUDE_DIR ${install_dir}/include
 	CACHE INTERNAL "Path to include folder for Docopt"
 )
-set(docopt_LIBRARIES ${install_dir}/lib/libdocopt_s.a
+set(docopt_LIBRARIES ${install_dir}/lib/libdocopt.a
 	CACHE INTERNAL "Path to libraries for Docopt"
 )


### PR DESCRIPTION
* Configuration was split in
  - Common configuration
  - Tracer configuration (for raycaster, raytracer and pathtracer)
  - Radiosity configuration
* USAGE for each executable is in a separate header file, to be able to use it in the tests.
* docopt response is parsed in the configuration, after that the program uses only config instance and no docopt anymore.
* new docopt version

Interesting fact: on my machine tests of configuration are pretty slow. Could be that string parsing in docopt is slow, or we are allocating too many strings in map.at lookup (Use heterogeneous map::find from C++14?).